### PR TITLE
Trim branch names and origin when applying settings form

### DIFF
--- a/src/main/java/com/nowsprinting/intellij_mob/config/ui/MobSettingsForm.java
+++ b/src/main/java/com/nowsprinting/intellij_mob/config/ui/MobSettingsForm.java
@@ -34,7 +34,7 @@ public class MobSettingsForm {
     }
 
     public void applyEditorTo(MobProjectSettings settings) {
-        settings.wipBranch = wipBranch.getText();
+        settings.wipBranch = wipBranch.getText().trim();
         settings.baseBranch = baseBranch.getText().trim();
         settings.remoteName = remoteName.getText();
         try {

--- a/src/main/java/com/nowsprinting/intellij_mob/config/ui/MobSettingsForm.java
+++ b/src/main/java/com/nowsprinting/intellij_mob/config/ui/MobSettingsForm.java
@@ -35,7 +35,7 @@ public class MobSettingsForm {
 
     public void applyEditorTo(MobProjectSettings settings) {
         settings.wipBranch = wipBranch.getText();
-        settings.baseBranch = baseBranch.getText();
+        settings.baseBranch = baseBranch.getText().trim();
         settings.remoteName = remoteName.getText();
         try {
             settings.timerMinutes = Integer.parseInt(timerMinutes.getText());

--- a/src/main/java/com/nowsprinting/intellij_mob/config/ui/MobSettingsForm.java
+++ b/src/main/java/com/nowsprinting/intellij_mob/config/ui/MobSettingsForm.java
@@ -36,7 +36,7 @@ public class MobSettingsForm {
     public void applyEditorTo(MobProjectSettings settings) {
         settings.wipBranch = wipBranch.getText().trim();
         settings.baseBranch = baseBranch.getText().trim();
-        settings.remoteName = remoteName.getText();
+        settings.remoteName = remoteName.getText().trim();
         try {
             settings.timerMinutes = Integer.parseInt(timerMinutes.getText());
         } catch (NumberFormatException e) {

--- a/src/test/kotlin/com/nowsprinting/intellij_mob/config/ui/MobSettingsFormTest.kt
+++ b/src/test/kotlin/com/nowsprinting/intellij_mob/config/ui/MobSettingsFormTest.kt
@@ -233,6 +233,10 @@ class MobSettingsFormTest {
     
     @Test
     fun applyEditorTo_modified_baseBranch_with_blanks() {
-        Assertions.assertTrue(true)
+        val settings = createDefaultSettings()
+        val sut = createDefaultForm()
+        sut.baseBranch.text = "develop    "
+        sut.applyEditorTo(settings)
+        Assertions.assertEquals("develop", settings.baseBranch)
     }
 }

--- a/src/test/kotlin/com/nowsprinting/intellij_mob/config/ui/MobSettingsFormTest.kt
+++ b/src/test/kotlin/com/nowsprinting/intellij_mob/config/ui/MobSettingsFormTest.kt
@@ -233,6 +233,6 @@ class MobSettingsFormTest {
     
     @Test
     fun applyEditorTo_modified_baseBranch_with_blanks() {
-        Assertions.assertTrue(false)
+        Assertions.assertTrue(1 == 2)
     }
 }

--- a/src/test/kotlin/com/nowsprinting/intellij_mob/config/ui/MobSettingsFormTest.kt
+++ b/src/test/kotlin/com/nowsprinting/intellij_mob/config/ui/MobSettingsFormTest.kt
@@ -235,8 +235,17 @@ class MobSettingsFormTest {
     fun applyEditorTo_modified_baseBranch_with_blanks() {
         val settings = createDefaultSettings()
         val sut = createDefaultForm()
-        sut.baseBranch.text = "develop    "
+        sut.baseBranch.text = "  develop    "
         sut.applyEditorTo(settings)
         Assertions.assertEquals("develop", settings.baseBranch)
+    }
+    
+    @Test
+    fun applyEditorTo_modified_wipBranch_with_blanks() {
+        val settings = createDefaultSettings()
+        val sut = createDefaultForm()
+        sut.wipBranch.text = "  mob-session    "
+        sut.applyEditorTo(settings)
+        Assertions.assertEquals("mob-session", settings.wipBranch)
     }
 }

--- a/src/test/kotlin/com/nowsprinting/intellij_mob/config/ui/MobSettingsFormTest.kt
+++ b/src/test/kotlin/com/nowsprinting/intellij_mob/config/ui/MobSettingsFormTest.kt
@@ -248,4 +248,13 @@ class MobSettingsFormTest {
         sut.applyEditorTo(settings)
         Assertions.assertEquals("mob-session", settings.wipBranch)
     }
+    
+    @Test
+    fun applyEditorTo_modified_remoteName_with_blanks() {
+        val settings = createDefaultSettings()
+        val sut = createDefaultForm()
+        sut.remoteName.text = "   upstream    "
+        sut.applyEditorTo(settings)
+        Assertions.assertEquals("upstream", settings.remoteName)
+    }
 }

--- a/src/test/kotlin/com/nowsprinting/intellij_mob/config/ui/MobSettingsFormTest.kt
+++ b/src/test/kotlin/com/nowsprinting/intellij_mob/config/ui/MobSettingsFormTest.kt
@@ -230,4 +230,9 @@ class MobSettingsFormTest {
         sut.applyEditorTo(settings)
         Assertions.assertTrue(settings.nextStay)
     }
+    
+    @Test
+    fun applyEditorTo_modified_baseBranch_with_blanks() {
+        Assertions.assertTrue(false)
+    }
 }

--- a/src/test/kotlin/com/nowsprinting/intellij_mob/config/ui/MobSettingsFormTest.kt
+++ b/src/test/kotlin/com/nowsprinting/intellij_mob/config/ui/MobSettingsFormTest.kt
@@ -233,6 +233,6 @@ class MobSettingsFormTest {
     
     @Test
     fun applyEditorTo_modified_baseBranch_with_blanks() {
-        Assertions.assertTrue(1 == 2)
+        Assertions.assertTrue(true)
     }
 }


### PR DESCRIPTION
When copying branch names from various chat tools, like MS-Teams or similar, sometimes additional whitespaces are copied, too. 

This pull request trims origin-, wip-branch- and base-branch-name when applying config form.

Fixes #18.

