### PR TITLE
Remove or skip steps that use secrets

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @nowsprinting

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -21,14 +21,3 @@ jobs:
         run: |
           bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
           ./actionlint -color
-
-      - uses: 8398a7/action-slack@v3
-        with:
-          status: ${{ job.status }}
-          fields: repo,message,job,took,eventName,ref,pullRequest
-          mention: here
-          if_mention: failure
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: failure()

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,6 +82,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         JAVA_HOME: '' # Avoid 'java: not found' error
+      if: github.repository_owner == 'remotemobprogramming' # Skip because can not read secrets from the public fork
 
     - name: Build plugin
       run: ./gradlew buildPlugin
@@ -90,13 +91,3 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         path: build/distributions
-
-    # Notification
-    - uses: 8398a7/action-slack@v3
-      with:
-        status: ${{ job.status }}
-        fields: repo,message,commit,author,action,eventName,ref,workflow # selectable (default: repo,message)
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # optional
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }} # required
-      if: always() # Pick up events even if the job fails or is canceled.


### PR DESCRIPTION
Remove or skip steps that use secrets.
Because the secret can not be read PR from the public fork

see https://github.community/t/have-github-action-only-run-on-master-repo-and-not-on-forks/140840/18